### PR TITLE
Automatically publish extension on tagged version

### DIFF
--- a/.github/workflows/publishextension.yml
+++ b/.github/workflows/publishextension.yml
@@ -1,0 +1,24 @@
+on:
+  push:
+    tags:
+      - "*"
+
+name: Deploy Extension
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - name: Publish to Open VSX Registry
+        uses: HaaLeo/publish-vscode-extension@v1
+        with:
+          pat: ${{ secrets.OPEN_VSX_TOKEN }}
+      - name: Publish to Visual Studio Marketplace
+        uses: HaaLeo/publish-vscode-extension@v1
+        with:
+          pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
+          registryUrl: https://marketplace.visualstudio.com


### PR DESCRIPTION
This should (???) publish the extension to the visual studio and openvsx extension hubs.

@wixoaGit you'll need to grab a token from @zewaka and make it available as 
`secrets.VS_MARKETPLACE_TOKEN` and one from openvsx as `secrets.OPEN_VSX_TOKEN`

I have literally no way of testing this so I guess just merge it and pray 